### PR TITLE
FIX: Changed header for fixing compilation error since we are  using …

### DIFF
--- a/MagicalRecord/Core/MagicalRecord+ShorthandMethods.h
+++ b/MagicalRecord/Core/MagicalRecord+ShorthandMethods.h
@@ -1,7 +1,7 @@
 //
 //  Copyright (c) 2015 Magical Panda Software LLC. All rights reserved.
 
-#import <MagicalRecord/MagicalRecord.h>
+#import <MagicalRecord/MagicalRecordInternal.h>
 
 @interface MagicalRecord (ShorthandMethods)
 


### PR DESCRIPTION
##### *To:*
@udemy/ios 

##### *What:*
- Changed header for fixing compilation error when we are using embedded framework. Same fix was proposed by community for cocoapods usage, see official PR [here](https://github.com/magicalpanda/MagicalRecord/pull/1281/files).

##### *Trello:*
https://trello.com/c/LPnTsLF7

##### *What did you test:*
Tested against the main app. There is already PR for main app with the already built framework.
This PR it's assure that if we make a new change, that we still have the fix when we need to rebuild the framework.
